### PR TITLE
fix: remove methods and change the signature of methods to prevent heap allocation

### DIFF
--- a/safe/bool.go
+++ b/safe/bool.go
@@ -6,6 +6,8 @@ import (
 
 // Bool wraps bool.
 // Bool must be used as the pointer because Bool has sync.RWMutex as a private field.
+// A RWMutex must not be copied after first use.
+// https://golang.org/pkg/sync/#RWMutex
 type Bool struct {
 	value bool
 	mutex sync.RWMutex

--- a/safe/bool.go
+++ b/safe/bool.go
@@ -4,15 +4,11 @@ import (
 	"sync"
 )
 
+// Bool wraps bool.
+// Bool must be used as the pointer because Bool has sync.RWMutex as a private field.
 type Bool struct {
 	value bool
 	mutex sync.RWMutex
-}
-
-func NewBool(v bool) *Bool {
-	return &Bool{
-		value: v,
-	}
 }
 
 func (s *Bool) Get() bool {

--- a/safe/bool_test.go
+++ b/safe/bool_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBool_Get(t *testing.T) {
 	v := true
-	age := NewBool(v)
+	age := &Bool{value: v}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	a := false
@@ -30,7 +30,7 @@ func TestBool_Get(t *testing.T) {
 }
 
 func TestBool_Set(t *testing.T) {
-	age := NewBool(false)
+	age := &Bool{}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -50,7 +50,7 @@ func TestBool_Set(t *testing.T) {
 }
 
 func TestBool_SetFunc(t *testing.T) {
-	age := NewBool(true)
+	age := &Bool{value: true}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -74,7 +74,7 @@ func TestBool_SetFunc(t *testing.T) {
 }
 
 func TestBool_Invert(t *testing.T) {
-	age := NewBool(false)
+	age := &Bool{}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -94,7 +94,7 @@ func TestBool_Invert(t *testing.T) {
 }
 
 func TestBool_InvertR(t *testing.T) {
-	age := NewBool(false)
+	age := &Bool{}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {

--- a/safe/bool_unsafe_test.go
+++ b/safe/bool_unsafe_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestBool_GetUnsafe(t *testing.T) {
 	v := true
-	age := NewBool(v)
+	age := &Bool{value: v}
 	a := age.GetUnsafe()
 	if a != v {
 		t.Fatalf("Bool.GetUnsafe() = %t, wanted %t", a, v)
@@ -15,7 +15,7 @@ func TestBool_GetUnsafe(t *testing.T) {
 
 func TestBool_SetUnsafe(t *testing.T) {
 	v := true
-	age := NewBool(false)
+	age := &Bool{}
 	age.SetUnsafe(v)
 	if age.value != v {
 		t.Fatalf("Bool.GetUnsafe() = %t, wanted %t", age.value, v)

--- a/safe/example_test.go
+++ b/safe/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Example() {
-	flag := safe.NewBool(false)
+	flag := &safe.Bool{}
 
 	data := map[string]int{
 		"foo": 1,

--- a/safe/int.go
+++ b/safe/int.go
@@ -5,17 +5,12 @@ import (
 )
 
 // Int wraps a int.
+// Int must be used as the pointer because Int has sync.RWMutex as a private field.
+// A RWMutex must not be copied after first use.
+// https://golang.org/pkg/sync/#RWMutex
 type Int struct {
 	value int
 	mutex sync.RWMutex
-}
-
-// NewInt creates a Int.
-// v is an initial value.
-func NewInt(v int) *Int {
-	return &Int{
-		value: v,
-	}
 }
 
 // Get gets a value with lock.

--- a/safe/int_test.go
+++ b/safe/int_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestInt_Get(t *testing.T) {
 	v := 5
-	age := NewInt(v)
+	age := &Int{value: v}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	a := 0
@@ -30,7 +30,7 @@ func TestInt_Get(t *testing.T) {
 }
 
 func TestInt_Set(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -49,7 +49,7 @@ func TestInt_Set(t *testing.T) {
 }
 
 func TestInt_SetFunc(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -72,7 +72,7 @@ func TestInt_SetFunc(t *testing.T) {
 }
 
 func TestInt_Add(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -91,7 +91,7 @@ func TestInt_Add(t *testing.T) {
 }
 
 func TestInt_AddR(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -110,7 +110,7 @@ func TestInt_AddR(t *testing.T) {
 }
 
 func TestInt_Sub(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -129,7 +129,7 @@ func TestInt_Sub(t *testing.T) {
 }
 
 func TestInt_SubR(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -148,7 +148,7 @@ func TestInt_SubR(t *testing.T) {
 }
 
 func TestInt_Mul(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -167,7 +167,7 @@ func TestInt_Mul(t *testing.T) {
 }
 
 func TestInt_MulR(t *testing.T) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -186,7 +186,7 @@ func TestInt_MulR(t *testing.T) {
 }
 
 func TestInt_Div(t *testing.T) {
-	age := NewInt(20)
+	age := &Int{value: 20}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -205,7 +205,7 @@ func TestInt_Div(t *testing.T) {
 }
 
 func TestInt_DivR(t *testing.T) {
-	age := NewInt(20)
+	age := &Int{value: 20}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -224,7 +224,7 @@ func TestInt_DivR(t *testing.T) {
 }
 
 func BenchmarkInt_Add(b *testing.B) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		age.Add(1)
@@ -232,7 +232,7 @@ func BenchmarkInt_Add(b *testing.B) {
 }
 
 func BenchmarkInt_AddR(b *testing.B) {
-	age := NewInt(5)
+	age := &Int{value: 5}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		age.AddR(1)

--- a/safe/int_unsafe_test.go
+++ b/safe/int_unsafe_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestInt_GetUnsafe(t *testing.T) {
 	v := 5
-	age := NewInt(v)
+	age := &Int{value: v}
 	a := age.GetUnsafe()
 	if a != v {
 		t.Fatalf("Int.GetUnsafe() = %d, wanted %d", a, v)
@@ -15,7 +15,7 @@ func TestInt_GetUnsafe(t *testing.T) {
 
 func TestInt_SetUnsafe(t *testing.T) {
 	v := 3
-	age := NewInt(0)
+	age := &Int{}
 	age.SetUnsafe(v)
 	if age.value != v {
 		t.Fatalf("Int.GetUnsafe() = %d, wanted %d", age.value, v)
@@ -23,7 +23,7 @@ func TestInt_SetUnsafe(t *testing.T) {
 }
 
 func TestInt_AddUnsafe(t *testing.T) {
-	age := NewInt(1)
+	age := &Int{value: 1}
 	age.AddUnsafe(3)
 	exp := 4
 	if age.value != exp {
@@ -32,7 +32,7 @@ func TestInt_AddUnsafe(t *testing.T) {
 }
 
 func TestInt_SubUnsafe(t *testing.T) {
-	age := NewInt(4)
+	age := &Int{value: 4}
 	age.SubUnsafe(1)
 	exp := 3
 	if age.value != exp {
@@ -41,7 +41,7 @@ func TestInt_SubUnsafe(t *testing.T) {
 }
 
 func TestInt_MulUnsafe(t *testing.T) {
-	age := NewInt(4)
+	age := &Int{value: 4}
 	age.MulUnsafe(2)
 	exp := 8
 	if age.value != exp {
@@ -50,7 +50,7 @@ func TestInt_MulUnsafe(t *testing.T) {
 }
 
 func TestInt_DivUnsafe(t *testing.T) {
-	age := NewInt(10)
+	age := &Int{value: 10}
 	age.DivUnsafe(2)
 	exp := 5
 	if age.value != exp {

--- a/safe/map_string.go
+++ b/safe/map_string.go
@@ -162,13 +162,11 @@ func (m *MapString) Copy() *MapString {
 	return ret
 }
 
-// CopyData copies an internal map[string]string and creates a new map[string]string.
-func (m *MapString) CopyData() map[string]string {
+// CopyData copies an internal map[string]string to target.
+func (m *MapString) CopyData(target map[string]string) {
 	m.mutex.RLock()
-	copiedM := make(map[string]string, len(m.value))
 	for k, v := range m.value {
-		copiedM[k] = v
+		target[k] = v
 	}
 	m.mutex.RUnlock()
-	return copiedM
 }

--- a/safe/map_string.go
+++ b/safe/map_string.go
@@ -18,11 +18,11 @@ func NewMapString(value map[string]string, size int) *MapString {
 	if s > size {
 		size = s
 	}
-	val := make(map[string]string, size)
+	val := make(map[string]string, size) // escapes to heap
 	for k, v := range value {
 		val[k] = v
 	}
-	return &MapString{
+	return &MapString{ // escapes to heap
 		value: val,
 	}
 }

--- a/safe/map_string_test.go
+++ b/safe/map_string_test.go
@@ -271,10 +271,10 @@ func TestMapString_CopyData(t *testing.T) {
 	age := NewMapString(map[string]string{"foo": "bar"}, 1)
 
 	var wg sync.WaitGroup
-	var cp map[string]string
+	cp := map[string]string{}
 	wg.Add(2)
 	go func() {
-		cp = age.CopyData()
+		age.CopyData(cp)
 		wg.Done()
 	}()
 	go func() {

--- a/safe/map_string_unsafe.go
+++ b/safe/map_string_unsafe.go
@@ -71,11 +71,9 @@ func (m *MapString) CopyUnsafe() *MapString {
 	return NewMapString(m.value, 0)
 }
 
-// CopyDataUnsafe copies an internal map[string]string and creates a new map[string]string without lock.
-func (m *MapString) CopyDataUnsafe() map[string]string {
-	copiedM := make(map[string]string, len(m.value))
+// CopyDataUnsafe copies an internal map[string]string to target without lock.
+func (m *MapString) CopyDataUnsafe(target map[string]string) {
 	for k, v := range m.value {
-		copiedM[k] = v
+		target[k] = v
 	}
-	return copiedM
 }

--- a/safe/map_string_unsafe_test.go
+++ b/safe/map_string_unsafe_test.go
@@ -132,7 +132,8 @@ func TestMapString_CopyUnsafe(t *testing.T) {
 
 func TestMapString_CopyDataUnsafe(t *testing.T) {
 	age := NewMapString(map[string]string{"foo": "bar"}, 1)
-	cp := age.CopyDataUnsafe()
+	cp := make(map[string]string, 1)
+	age.CopyDataUnsafe(cp)
 
 	exp := 1
 	a := len(cp)

--- a/safe/string.go
+++ b/safe/string.go
@@ -40,7 +40,7 @@ func (s *String) Add(v string) {
 
 func (s *String) AddR(v string) string {
 	s.mutex.Lock()
-	a := s.value + v
+	a := s.value + v // escapes to heap
 	s.value = a
 	s.mutex.Unlock()
 	return a

--- a/safe/string.go
+++ b/safe/string.go
@@ -4,15 +4,13 @@ import (
 	"sync"
 )
 
+// String wraps bool.
+// String must be used as the pointer because String has sync.RWMutex as a private field.
+// A RWMutex must not be copied after first use.
+// https://golang.org/pkg/sync/#RWMutex
 type String struct {
 	value string
 	mutex sync.RWMutex
-}
-
-func NewString(v string) *String {
-	return &String{
-		value: v,
-	}
 }
 
 func (s *String) Get() string {

--- a/safe/string_test.go
+++ b/safe/string_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestString_Get(t *testing.T) {
 	v := "hello"
-	age := NewString(v)
+	age := &String{value: v}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	a := ""
@@ -30,7 +30,7 @@ func TestString_Get(t *testing.T) {
 }
 
 func TestString_Set(t *testing.T) {
-	age := NewString("hello")
+	age := &String{value: "hello"}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -49,7 +49,7 @@ func TestString_Set(t *testing.T) {
 }
 
 func TestString_SetFunc(t *testing.T) {
-	age := NewString("hello")
+	age := &String{value: "hello"}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -73,7 +73,7 @@ func TestString_SetFunc(t *testing.T) {
 }
 
 func TestString_Add(t *testing.T) {
-	age := NewString("hello")
+	age := &String{value: "hello"}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -93,7 +93,7 @@ func TestString_Add(t *testing.T) {
 }
 
 func TestString_AddR(t *testing.T) {
-	age := NewString("hello")
+	age := &String{value: "hello"}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -113,7 +113,7 @@ func TestString_AddR(t *testing.T) {
 }
 
 func BenchmarkString_Add(b *testing.B) {
-	age := NewString("")
+	age := &String{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		age.Add("h")
@@ -121,7 +121,7 @@ func BenchmarkString_Add(b *testing.B) {
 }
 
 func BenchmarkString_AddR(b *testing.B) {
-	age := NewString("")
+	age := &String{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		age.AddR("h")

--- a/safe/string_unsafe_test.go
+++ b/safe/string_unsafe_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestString_GetUnsafe(t *testing.T) {
 	v := "hello"
-	age := NewString(v)
+	age := &String{value: v}
 	a := age.GetUnsafe()
 	if a != v {
 		t.Fatalf("String.GetUnsafe() = %s, wanted %s", a, v)
@@ -15,7 +15,7 @@ func TestString_GetUnsafe(t *testing.T) {
 
 func TestString_SetUnsafe(t *testing.T) {
 	v := "foo"
-	age := NewString("")
+	age := &String{}
 	age.SetUnsafe(v)
 	if age.value != v {
 		t.Fatalf("String.GetUnsafe() = %s, wanted %s", age.value, v)
@@ -24,7 +24,7 @@ func TestString_SetUnsafe(t *testing.T) {
 
 func TestString_AddUnsafe(t *testing.T) {
 	v := " foo"
-	age := NewString("hello")
+	age := &String{value: "hello"}
 	age.AddUnsafe(v)
 	exp := "hello foo"
 	if age.value != exp {


### PR DESCRIPTION
Remove methods and change the signature of methods to prevent the heap allocation.

## Remove methods

* NewBool
* NewInt
* NewString

AS IS

```go
flag := safe.NewBool(true)
```

TO BE

```go
flag := &safe.Bool{}
flag.SetUnsafe(true)
```

## Change the signature

* MapString.CopyData
* MapString.CopyDataUnsafe

AS IS

```go
a := mapString.CopyData()
```

TO BE

```go
a := make(map[string]string, mapString.Len())
mapString.CopyData(a)
```