### PR TITLE
fix: change the signature of some functions to prevent heap allocation

### DIFF
--- a/safe/map_string.go
+++ b/safe/map_string.go
@@ -7,25 +7,19 @@ import (
 )
 
 // MapString wraps map[string]string.
+// MapString must be created by NewMapString.
 type MapString struct {
 	value map[string]string
 	mutex sync.RWMutex
 }
 
 // NewMapString creates a MapString.
-// The key and values of `value` are copied to MapString.
-// size is an initial map size.
-func NewMapString(value map[string]string, size int) *MapString {
-	s := len(value)
-	if s > size {
-		size = s
-	}
-	val := make(map[string]string, size) // escapes to heap
-	for k, v := range value {
-		val[k] = v
-	}
+// The argument `value` must not be nil.
+// Note that the argument `value` is holden in MapString, so don't read and write `value` out of the MapString.
+func NewMapString(value map[string]string) *MapString {
+	// To avoid the heap allocation, don't copy `value` and create a new map.
 	return &MapString{ // escapes to heap
-		value: val,
+		value: value,
 	}
 }
 
@@ -178,11 +172,12 @@ func (m *MapString) RangeB(f func(k, v string) bool) {
 }
 
 // Copy copies and creates a new MapString.
-func (m *MapString) Copy() *MapString {
+func (m *MapString) Copy(target *MapString) {
 	m.mutex.RLock()
-	ret := NewMapString(m.value, 0)
+	for k, v := range m.value {
+		target.value[k] = v
+	}
 	m.mutex.RUnlock()
-	return ret
 }
 
 // CopyData copies an internal map[string]string to target.

--- a/safe/map_string_test.go
+++ b/safe/map_string_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMapString_String(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 0)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	var wg sync.WaitGroup
 	wg.Add(2)
 	a := ""
@@ -28,7 +28,7 @@ func TestMapString_String(t *testing.T) {
 }
 
 func TestMapString_MarshalJSON(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 0)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	var wg sync.WaitGroup
 	wg.Add(2)
 	var err error
@@ -57,7 +57,7 @@ func TestMapString_MarshalJSON(t *testing.T) {
 }
 
 func TestMapString_UnmarshalJSON(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 0)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	var wg sync.WaitGroup
 	buf := []byte(`{"hello":"world"}`)
 	wg.Add(2)
@@ -88,7 +88,7 @@ func TestMapString_UnmarshalJSON(t *testing.T) {
 }
 
 func TestMapString_Get(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 0)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -112,7 +112,7 @@ func TestMapString_Get(t *testing.T) {
 }
 
 func TestMapString_GetOk(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -139,7 +139,7 @@ func TestMapString_GetOk(t *testing.T) {
 }
 
 func TestMapString_Has(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	key := "foo"
 
 	var wg sync.WaitGroup
@@ -162,7 +162,7 @@ func TestMapString_Has(t *testing.T) {
 }
 
 func TestMapString_Len(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -183,7 +183,7 @@ func TestMapString_Len(t *testing.T) {
 }
 
 func TestMapString_Delete(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -205,7 +205,7 @@ func TestMapString_Delete(t *testing.T) {
 
 func TestMapString_DeleteR(t *testing.T) {
 	exp := "bar" //nolint:goconst
-	age := NewMapString(map[string]string{"foo": exp}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -227,7 +227,7 @@ func TestMapString_DeleteR(t *testing.T) {
 
 func TestMapString_DeleteROk(t *testing.T) {
 	exp := "bar"
-	age := NewMapString(map[string]string{"foo": exp}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -251,7 +251,7 @@ func TestMapString_DeleteROk(t *testing.T) {
 }
 
 func TestMapString_Set(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	exp := "zoo"
 
 	var wg sync.WaitGroup
@@ -273,7 +273,7 @@ func TestMapString_Set(t *testing.T) {
 }
 
 func TestMapString_SetFunc(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.SetFunc("foo", func(v string, ok bool) string {
 		return v + " world"
 	})
@@ -285,7 +285,7 @@ func TestMapString_SetFunc(t *testing.T) {
 }
 
 func TestMapString_Range(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.Range(func(k, v string) {
 		if k != "foo" {
 			t.Fatalf("k = %s, wanted %s", k, "foo")
@@ -305,7 +305,7 @@ func TestMapString_Range(t *testing.T) {
 }
 
 func TestMapString_RangeB(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.RangeB(func(k, v string) bool {
 		if k != "foo" {
 			t.Fatalf("k = %s, wanted %s", k, "foo")
@@ -327,13 +327,13 @@ func TestMapString_RangeB(t *testing.T) {
 }
 
 func TestMapString_Copy(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
-	var cp *MapString
+	cp := NewMapString(map[string]string{})
 	wg.Add(2)
 	go func() {
-		cp = age.Copy()
+		age.Copy(cp)
 		wg.Done()
 	}()
 	go func() {
@@ -350,7 +350,7 @@ func TestMapString_Copy(t *testing.T) {
 }
 
 func TestMapString_CopyData(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	cp := map[string]string{}
@@ -373,7 +373,7 @@ func TestMapString_CopyData(t *testing.T) {
 }
 
 func TestMapString_SetDefault(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -401,7 +401,7 @@ func TestMapString_SetDefault(t *testing.T) {
 }
 
 func TestMapString_SetDefaultR(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -430,7 +430,7 @@ func TestMapString_SetDefaultR(t *testing.T) {
 
 func BenchmarkMapString_Set(b *testing.B) {
 	key := "foo"
-	age := NewMapString(map[string]string{key: "bar"}, 1)
+	age := NewMapString(map[string]string{key: "bar"})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a := age.Get(key)
@@ -440,11 +440,19 @@ func BenchmarkMapString_Set(b *testing.B) {
 
 func BenchmarkMapString_SetFunc(b *testing.B) {
 	key := "foo"
-	age := NewMapString(map[string]string{key: "bar"}, 1)
+	age := NewMapString(map[string]string{key: "bar"})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		age.SetFunc(key, func(v string, ok bool) string {
 			return v + " world"
 		})
+	}
+}
+
+func BenchmarkNewMapString(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		age := NewMapString(map[string]string{"foo": "bar"})
+		age.LenUnsafe()
 	}
 }

--- a/safe/map_string_unsafe.go
+++ b/safe/map_string_unsafe.go
@@ -67,8 +67,10 @@ func (m *MapString) RangeBUnsafe(f func(k, v string) bool) {
 }
 
 // CopyUnsafe copies and creates a new MapString without lock.
-func (m *MapString) CopyUnsafe() *MapString {
-	return NewMapString(m.value, 0)
+func (m *MapString) CopyUnsafe(target *MapString) {
+	for k, v := range m.value {
+		target.value[k] = v
+	}
 }
 
 // CopyDataUnsafe copies an internal map[string]string to target without lock.

--- a/safe/map_string_unsafe_test.go
+++ b/safe/map_string_unsafe_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMapString_GetUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	a := age.GetUnsafe("foo")
 	exp := "bar"
 	if a != exp {
@@ -14,7 +14,7 @@ func TestMapString_GetUnsafe(t *testing.T) {
 }
 
 func TestMapString_GetOkUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	a, ok := age.GetOkUnsafe("foo")
 	exp := "bar"
 	if a != exp {
@@ -26,7 +26,7 @@ func TestMapString_GetOkUnsafe(t *testing.T) {
 }
 
 func TestMapString_HasUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	ok := age.HasUnsafe("foo")
 	if !ok {
 		t.Fatalf("MapString.HasUnsafe() = %t, wanted %t", ok, false)
@@ -34,7 +34,7 @@ func TestMapString_HasUnsafe(t *testing.T) {
 }
 
 func TestMapString_LenUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	a := age.LenUnsafe()
 	if a != 1 {
 		t.Fatalf("MapString.LenUnsafe() = %d, wanted %d", a, 1)
@@ -42,7 +42,7 @@ func TestMapString_LenUnsafe(t *testing.T) {
 }
 
 func TestMapString_DeleteUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.DeleteUnsafe("foo")
 	a := len(age.value)
 	if a != 0 {
@@ -51,7 +51,7 @@ func TestMapString_DeleteUnsafe(t *testing.T) {
 }
 
 func TestMapString_SetUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	exp := "zoo"
 	age.SetUnsafe("foo", exp)
 	a := age.value["foo"]
@@ -63,7 +63,7 @@ func TestMapString_SetUnsafe(t *testing.T) {
 func TestMapString_SetDefaultUnsafe(t *testing.T) {
 	exp := "bar"
 	key := "foo"
-	age := NewMapString(map[string]string{key: exp}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.SetDefaultUnsafe(key, "zoo")
 	a := age.value[key]
 	if a != exp {
@@ -80,7 +80,7 @@ func TestMapString_SetDefaultUnsafe(t *testing.T) {
 func TestMapString_SetDefaultRUnsafe(t *testing.T) {
 	exp := "bar"
 	key := "foo"
-	age := NewMapString(map[string]string{key: exp}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.SetDefaultRUnsafe(key, "zoo")
 	a := age.value[key]
 	if a != exp {
@@ -95,7 +95,7 @@ func TestMapString_SetDefaultRUnsafe(t *testing.T) {
 }
 
 func TestMapString_RangeUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.RangeUnsafe(func(k, v string) {
 		if k != "foo" {
 			t.Fatalf("k = %s, wanted %s", k, "foo")
@@ -107,7 +107,7 @@ func TestMapString_RangeUnsafe(t *testing.T) {
 }
 
 func TestMapString_RangeBUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	age.RangeBUnsafe(func(k, v string) bool {
 		if k != "foo" {
 			t.Fatalf("k = %s, wanted %s", k, "foo")
@@ -120,8 +120,9 @@ func TestMapString_RangeBUnsafe(t *testing.T) {
 }
 
 func TestMapString_CopyUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
-	cp := age.CopyUnsafe()
+	age := NewMapString(map[string]string{"foo": "bar"})
+	cp := NewMapString(map[string]string{})
+	age.CopyUnsafe(cp)
 
 	exp := 1
 	a := len(cp.value)
@@ -131,7 +132,7 @@ func TestMapString_CopyUnsafe(t *testing.T) {
 }
 
 func TestMapString_CopyDataUnsafe(t *testing.T) {
-	age := NewMapString(map[string]string{"foo": "bar"}, 1)
+	age := NewMapString(map[string]string{"foo": "bar"})
 	cp := make(map[string]string, 1)
 	age.CopyDataUnsafe(cp)
 


### PR DESCRIPTION
* NewMapString
* MapString.Copy
* MapString.CopyUnsafe